### PR TITLE
Fix/v0.1.4

### DIFF
--- a/mvnw
+++ b/mvnw
@@ -58,7 +58,7 @@ case "$(uname)" in
   MINGW*) mingw=true;;
   Darwin*) darwin=true
     # Use /usr/libexec/java_home if available, otherwise fall back to /Library/Java/Home
-    # See https://developer.apple.com/library/mac/qa/qa1170/_index.html
+    # See https://developer.PLANE.com/library/mac/qa/qa1170/_index.html
     if [ -z "$JAVA_HOME" ]; then
       if [ -x "/usr/libexec/java_home" ]; then
         JAVA_HOME="$(/usr/libexec/java_home)"; export JAVA_HOME

--- a/src/main/java/com/wordleapp/controller/WordleController.java
+++ b/src/main/java/com/wordleapp/controller/WordleController.java
@@ -8,7 +8,7 @@ import org.springframework.web.server.ResponseStatusException;
 @RequestMapping("/api/wordle")
 public class WordleController {
 
-    private static final String SECRET_WORD = "APPLE"; // Hardcoded for now
+    private static final String SECRET_WORD = "PLANE"; // Hardcoded for now
 
     @PostMapping("/guess")
     public String checkWord(@RequestParam String guess) {

--- a/src/test/java/com/wordleapp/api/WordleApiTest.java
+++ b/src/test/java/com/wordleapp/api/WordleApiTest.java
@@ -21,7 +21,7 @@ class WordleApiTest {
         given()
                 .contentType(ContentType.JSON)
                 .when()
-                .post("/guess?guess=APPLE")
+                .post("/guess?guess=PLANE")
                 .then()
                 .statusCode(200)
                 .body(equalTo("Correct!"));

--- a/src/test/java/com/wordleapp/integration/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/wordleapp/integration/GlobalExceptionHandlerTest.java
@@ -23,10 +23,11 @@ class GlobalExceptionHandlerTest {
             "12+, Invalid input: Only characters from the alphabet are allowed.",
             "12345, Invalid input: Only characters from the alphabet are allowed.",
             "APP, Invalid input: The word must be 5 letters long.",
-            "H3LLO, Invalid input: Only characters from the alphabet are allowed.",
+            "plan, Invalid input: The word must be 5 letters long.",
             "<apa, Invalid input: Only characters from the alphabet are allowed.",
             "Tbl?, Invalid input: Only characters from the alphabet are allowed.",
             "'fuel,', Invalid input: Only characters from the alphabet are allowed.",
+            "plAn3, Invalid input: Only characters from the alphabet are allowed.",
 
     })
     void shouldHandleResponseStatusException(String guess, String expectedMessage) throws Exception {

--- a/src/test/java/com/wordleapp/integration/WordleControllerTest.java
+++ b/src/test/java/com/wordleapp/integration/WordleControllerTest.java
@@ -1,13 +1,11 @@
 package com.wordleapp.integration;
 
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.ResultMatcher;
 
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -21,7 +19,7 @@ class WordleControllerTest {
     private MockMvc mockMvc;
 
     @ParameterizedTest
-    @ValueSource(strings = {"PLANE", "plane", "GRAPE", "MANGO", "BERRY"})
+    @ValueSource(strings = {"PLANE", "plane", "plano"})
     void testWordGuess(String word) throws Exception {
         boolean isCorrect = word.equalsIgnoreCase("PLANE");
 

--- a/src/test/java/com/wordleapp/integration/WordleControllerTest.java
+++ b/src/test/java/com/wordleapp/integration/WordleControllerTest.java
@@ -21,9 +21,9 @@ class WordleControllerTest {
     private MockMvc mockMvc;
 
     @ParameterizedTest
-    @ValueSource(strings = {"APPLE", "apple", "GRAPE", "MANGO", "BERRY"})
+    @ValueSource(strings = {"PLANE", "plane", "GRAPE", "MANGO", "BERRY"})
     void testWordGuess(String word) throws Exception {
-        boolean isCorrect = word.equalsIgnoreCase("APPLE");
+        boolean isCorrect = word.equalsIgnoreCase("PLANE");
 
         mockMvc.perform(post("/api/wordle/guess").param("guess", word))
                 .andExpect(status().isOk())

--- a/src/test/java/com/wordleapp/ui/WordleUITest.java
+++ b/src/test/java/com/wordleapp/ui/WordleUITest.java
@@ -36,7 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
     @ParameterizedTest
     @CsvSource({
-            "APPLE, Correct!",
+            "PLANE, Correct!",
             "PEACH, Try again!",
             "APP, Invalid input: The word must be 5 letters long.",
             "H3LLO, Invalid input: Only characters from the alphabet are allowed."


### PR DESCRIPTION
Changing secret word from "apple" to "plane". This change was done because:
Must not repeat letters → To maximize diversity in validation testing.
Must contain several vowels and consonants → To ensure that the algorithm handles different types of letters.
Must be a common word → To be easily recognized by users.